### PR TITLE
Replaces source with rendered code in docspage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist-ssr
 *.local
 .npmrc
 coverage
+*.log
+.envrc
+storybook-static/

--- a/lib/components/button/Button.stories.js
+++ b/lib/components/button/Button.stories.js
@@ -59,6 +59,13 @@ export default {
       },
     },
   },
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic'
+      }
+    }
+  },
 };
 
 const Template = (args) => <Button {...args} />;


### PR DESCRIPTION
According to this article: https://storybook.js.org/docs/react/writing-docs/doc-blocks#docspage-1

There is a way to configure stories to display generated snippets on the DocsPage instead of source. Maybe we can find a way to apply this automatically to all stories; in a template perhaps? Something to work off of.

## Before
![image](https://user-images.githubusercontent.com/2065615/115634196-b6df9200-a2ce-11eb-9ecd-5f0d5380b2d3.png)

## After
![image](https://user-images.githubusercontent.com/2065615/115634216-bf37cd00-a2ce-11eb-9e96-5635a0b2ac48.png)
