### PR TITLE
decrease vertical spacing

### DIFF
--- a/lib/components/checkbox/CheckboxGroup.jsx
+++ b/lib/components/checkbox/CheckboxGroup.jsx
@@ -15,7 +15,7 @@ export function CheckboxGroup({ children, horizontal, ...props }) {
                 },
               }
             : {
-                '.chakra-checkbox': { mt: 1 },
+                '.chakra-checkbox': { mt: 'mg0' },
                 '.chakra-checkbox:first-of-type': {
                   mt: '0px',
                 },

--- a/lib/components/radio/RadioGroup.jsx
+++ b/lib/components/radio/RadioGroup.jsx
@@ -15,7 +15,7 @@ export function RadioGroup({ children, horizontal, ...props }) {
                 },
               }
             : {
-                '.chakra-radio': { mt: 1 },
+                '.chakra-radio': { mt: 'mg0' },
                 '.chakra-radio:first-of-type': {
                   mt: '0px',
                 },


### PR DESCRIPTION
Just decreases vertical spacing for radio and checkbox groups from `2px (sg0) from 8px (s1)`

[Update vertical alignment gap for Checkbox and Radio to 2px](https://app.clubhouse.io/firehydrant/story/17938/update-vertical-alignment-gap-for-checkbox-and-radio-to-2px)