### PR TITLE
Add container component

### DIFF
--- a/lib/components/container/Container.jsx
+++ b/lib/components/container/Container.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Container as ChakraContainer } from '@chakra-ui/react';
+
+export function Container({ children, ...rest }) {
+  return <ChakraContainer {...rest}>{children}</ChakraContainer>;
+}

--- a/lib/components/container/Container.stories.js
+++ b/lib/components/container/Container.stories.js
@@ -1,0 +1,74 @@
+import React from 'react';
+// import { Text, Button } from '../../main';
+import { Container } from './Container';
+
+export default {
+  title: 'Components/Layout/Container',
+  component: Container,
+  argTypes: {
+    children: {
+      description: 'Inner element or text for element',
+      table: {
+        type: { summary: 'text|node' },
+      },
+    },
+    size: {
+      description: 'Maximum width',
+      table: {
+        type: { summary: 'null|1100|1400' },
+        defaultValue: { summary: '60ch' },
+      },
+      control: {
+        type: 'radio',
+        defaultValue: '60ch',
+        options: ['null', '1100', '1400'],
+      },
+    },
+    centerContent: {
+      description: 'Center-align the content',
+      table: {
+        type: { summary: 'true|false' },
+        defaultValue: { summary: 'false' },
+      },
+      control: {
+        type: 'boolean',
+        defaultValue: 'false',
+      },
+    },
+  },
+};
+
+const Template = (args) => (
+  <Container
+    sx={{
+      p: 2,
+      bg: 'white',
+      border: '1px',
+      borderColor: 'gray.200',
+    }}
+    {...args}
+  />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  children: 'Container constrained to 60ch by default.',
+};
+
+export const Container1100 = Template.bind({});
+Container1100.args = {
+  size: '1100',
+  children: 'Container constrained to 1100px for general page layout.',
+};
+
+export const Container1400 = Template.bind({});
+Container1400.args = {
+  size: '1400',
+  children: 'Container constrained to 1400px for larger page layout.',
+};
+
+export const CenterContent = Template.bind({});
+CenterContent.args = {
+  centerContent: true,
+  children: 'Container content center-aligned.',
+};

--- a/lib/components/container/Container.stories.js
+++ b/lib/components/container/Container.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import { Text, Button } from '../../main';
 import { Container } from './Container';
 
 export default {
@@ -8,12 +7,17 @@ export default {
   argTypes: {
     children: {
       description: 'Inner element or text for element',
+      defaultValue:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sodales mi eget nisl vehicula, ac consequat felis gravida. Donec pellentesque tortor id pharetra cursus. Nulla facilisi. Maecenas porttitor lacinia convallis. Aenean eget sem viverra, sollicitudin mi quis, sodales nunc. Pellentesque sollicitudin, massa id maximus fermentum, lacus sapien tempor turpis, at tristique magna nibh et orci.',
       table: {
         type: { summary: 'text|node' },
       },
+      control: {
+        type: 'object',
+      },
     },
     size: {
-      description: 'Maximum width',
+      description: 'maximum width',
       table: {
         type: { summary: 'null|1100|1400' },
         defaultValue: { summary: '60ch' },
@@ -25,7 +29,7 @@ export default {
       },
     },
     centerContent: {
-      description: 'Center-align the content',
+      description: 'container will center its children',
       table: {
         type: { summary: 'true|false' },
         defaultValue: { summary: 'false' },
@@ -38,37 +42,22 @@ export default {
   },
 };
 
-const Template = (args) => (
-  <Container
-    sx={{
-      p: 2,
-      bg: 'white',
-      border: '1px',
-      borderColor: 'gray.200',
-    }}
-    {...args}
-  />
-);
+const Template = (args) => <Container {...args} />;
 
 export const Default = Template.bind({});
-Default.args = {
-  children: 'Container constrained to 60ch by default.',
-};
 
 export const Container1100 = Template.bind({});
 Container1100.args = {
   size: '1100',
-  children: 'Container constrained to 1100px for general page layout.',
 };
 
 export const Container1400 = Template.bind({});
 Container1400.args = {
   size: '1400',
-  children: 'Container constrained to 1400px for larger page layout.',
 };
 
 export const CenterContent = Template.bind({});
 CenterContent.args = {
   centerContent: true,
-  children: 'Container content center-aligned.',
+  children: 'Container will center its children',
 };

--- a/lib/components/container/container.theme.js
+++ b/lib/components/container/container.theme.js
@@ -1,0 +1,11 @@
+export const Container = {
+  baseStyle: {},
+  sizes: {
+    1100: {
+      maxW: '1100px',
+    },
+    1400: {
+      maxW: '1400px',
+    },
+  },
+};

--- a/lib/components/container/index.js
+++ b/lib/components/container/index.js
@@ -1,0 +1,1 @@
+export * from './Container';

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 export * from './components/button';
 export * from './components/checkbox';
 export * from './components/card';
+export * from './components/container';
 export * from './components/iconbutton';
 export * from './components/icons';
 export * from './components/text';

--- a/lib/theme/index.js
+++ b/lib/theme/index.js
@@ -1,6 +1,7 @@
 import { Button } from '../components/button/button.theme';
 import { Card, CardHeader } from '../components/card/card.theme';
 import { Checkbox } from '../components/checkbox/checkbox.theme';
+import { Container } from '../components/container/container.theme';
 import { extendTheme } from '@chakra-ui/react';
 import { FormLabel } from '../components/formlabel/formlabel.theme';
 import { Link } from '../components/link/link.theme';
@@ -23,6 +24,7 @@ export default extendTheme({
     Card,
     CardHeader,
     Checkbox,
+    Container,
     FormLabel,
     Input,
     Link,


### PR DESCRIPTION
Adds container component with two provided sizes: `1100px` and `1400px` maxWidth. 

By default, without the `size` prop, the component will constrain to 60ch- I feel this is an acceptable fall back because it falls within the optimal legibility range for text. 