### PR TITLE
Remove unused prop

### DIFF
--- a/lib/components/button/Button.stories.js
+++ b/lib/components/button/Button.stories.js
@@ -78,7 +78,6 @@ Primary.args = {
 export const PrimaryLoading = Template.bind({});
 PrimaryLoading.args = {
   children: 'Click Me',
-  alignItems: 'center',
   isLoading: true,
 };
 

--- a/lib/components/button/button.theme.js
+++ b/lib/components/button/button.theme.js
@@ -15,7 +15,6 @@ export const Button = {
       lineHeight: '24px',
       whiteSpace: 'normal',
       height: 'auto',
-      alignItems: 'flex-end',
       minHeight: '40px',
       minWidth: '40px',
     },


### PR DESCRIPTION
This hack was put into place when we still had the icon being flexed to the end but wanted the loading indicator to work correctly. This is no longer needed since Chakra updated to always have the icon centered.