### PR TITLE
set default tab bg color

### DIFF
--- a/lib/components/tabs/tabs.theme.js
+++ b/lib/components/tabs/tabs.theme.js
@@ -20,6 +20,7 @@ export const Tabs = {
           py: 1,
           px: 2,
           my: 'mg0',
+          bg: 'grey.0',
           justifyContent: orientation === 'vertical' ? 'left' : 'center',
           color: 'purple.70',
           boxShadow: 'none',


### PR DESCRIPTION
I noticed that since our storybook is white you can't see this but when implementing tabs in laddertruck since their isn't a default background color it goes with the default greyish background. Tabs should always be  grey.0 to start.

![image](https://user-images.githubusercontent.com/10525357/119392196-14cc1480-bc95-11eb-87be-e90b76817845.png)
