### PR TITLE
switch to border bottom as safari doesn't allow for box-shadow on tr elements

### DIFF
--- a/lib/components/table/table.theme.js
+++ b/lib/components/table/table.theme.js
@@ -6,8 +6,8 @@ export const Table = {
     simple: ({ verticalAlign }) => ({
       table: { bg: 'grey.0' },
       tr: {
-        borderBottom: 'none',
-        boxShadow: `0px -1px 0px 0px ${colors.grey[30]} inset`,
+        borderBottom: '1px solid',
+        borderColor: 'grey.30',
       },
       th: {
         borderBottom: 'none',


### PR DESCRIPTION
Box Shadow doesn't work on tr elements in safari so this switches it up to use border-bottom as Chakra already was using before.

![image](https://user-images.githubusercontent.com/10525357/119731203-3fa49d00-be3c-11eb-95c6-c173f41a9d0e.png)


