### PR TITLE
Minor fixes for links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [1.0.5] - 2021-06-01
+
+### Fixed
+
+- Uses a span for the Text inside of the Link component
+
+## [1.0.4] - 2021-05-28
+
+### Fixed
+
+- Removed React as a internal dependency
+
 ## [1.0.3] - 2021-05-27
 
 ### Fixed

--- a/lib/components/link/Link.stories.js
+++ b/lib/components/link/Link.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from '../../main';
 import { Link } from './Link';
 
 export default {
@@ -41,6 +42,36 @@ const Template = (args) => <Link {...args} />;
 
 export const Default = Template.bind({});
 Default.args = { children: 'Link text', href: '#' };
+
+export const ParagraphLink = () => (
+  <Text>
+    Create consistency for the entire incident response lifecycle with{' '}
+    <Link rel="noopener" target="_blank" href="https://firehydrant.io/">
+      FireHydrant
+    </Link>
+    , the incident management platform for teams of all sizes.
+  </Text>
+);
+
+export const LongParagraphLink = () => (
+  <Text>
+    Paragraphs are the building blocks of papers. Many students define
+    paragraphs in terms of length: a paragraph is a group of at least five
+    sentences, a paragraph is half a page long, etc. In reality, though, the
+    unity and coherence of ideas among sentences is what constitutes a
+    paragraph. A paragraph is defined as “a group of sentences or a single
+    sentence that forms a unit” (Lunsford and Connors 116). Length and
+    appearance do not determine whether a section in a paper is a paragraph. For
+    instance, in some styles of writing, particularly journalistic styles, a
+    paragraph can be just one sentence long.{' '}
+    <Link href="#">
+      Ultimately, a paragraph is a sentence or group of sentences that support
+      one main idea.
+    </Link>{' '}
+    In this handout, we will refer to this as the “controlling idea,” because it
+    controls what happens in the rest of the paragraph.
+  </Text>
+);
 
 export const SizeSixLink = Template.bind({});
 SizeSixLink.args = { children: 'Link text', href: '#', size: 6 };
@@ -112,6 +143,47 @@ ReverseExternalLink.args = {
   variant: 'reverse',
 };
 ReverseExternalLink.parameters = {
+  backgrounds: { default: 'dark' },
+};
+
+export const ParagraphLinkReverse = () => (
+  <Text color="grey.0">
+    Create consistency for the entire incident response lifecycle with{' '}
+    <Link
+      variant="reverse"
+      rel="noopener"
+      target="_blank"
+      href="https://firehydrant.io/"
+    >
+      FireHydrant
+    </Link>
+    , the incident management platform for teams of all sizes.
+  </Text>
+);
+ParagraphLinkReverse.parameters = {
+  backgrounds: { default: 'dark' },
+};
+
+export const LongParagraphLinkReverse = () => (
+  <Text color="grey.0">
+    Paragraphs are the building blocks of papers. Many students define
+    paragraphs in terms of length: a paragraph is a group of at least five
+    sentences, a paragraph is half a page long, etc. In reality, though, the
+    unity and coherence of ideas among sentences is what constitutes a
+    paragraph. A paragraph is defined as “a group of sentences or a single
+    sentence that forms a unit” (Lunsford and Connors 116). Length and
+    appearance do not determine whether a section in a paper is a paragraph. For
+    instance, in some styles of writing, particularly journalistic styles, a
+    paragraph can be just one sentence long.{' '}
+    <Link variant="reverse" href="#">
+      Ultimately, a paragraph is a sentence or group of sentences that support
+      one main idea.
+    </Link>{' '}
+    In this handout, we will refer to this as the “controlling idea,” because it
+    controls what happens in the rest of the paragraph.
+  </Text>
+);
+LongParagraphLinkReverse.parameters = {
   backgrounds: { default: 'dark' },
 };
 

--- a/lib/components/link/Link.stories.js
+++ b/lib/components/link/Link.stories.js
@@ -67,6 +67,15 @@ SizeSevenExternalLink.args = {
   isExternal: true,
 };
 
+export const SizeSevenExternalLongLink = Template.bind({});
+SizeSevenExternalLongLink.args = {
+  children: 'This is a very long link that should wrap when it needs to.',
+  href: '#',
+  size: 7,
+  isExternal: true,
+  maxWidth: '100px',
+};
+
 export const ReverseLink = Template.bind({});
 ReverseLink.args = { children: 'Link text', href: '#', variant: 'reverse' };
 ReverseLink.parameters = {
@@ -127,5 +136,18 @@ SizeSevenReverseExternalLink.args = {
   isExternal: true,
 };
 SizeSevenReverseExternalLink.parameters = {
+  backgrounds: { default: 'dark' },
+};
+
+export const SizeSevenReverseExternalLongLink = Template.bind({});
+SizeSevenReverseExternalLongLink.args = {
+  children: 'This is a very long link that should wrap when it needs to.',
+  href: '#',
+  size: 7,
+  isExternal: true,
+  variant: 'reverse',
+  maxWidth: '100px',
+};
+SizeSevenReverseExternalLongLink.parameters = {
   backgrounds: { default: 'dark' },
 };

--- a/lib/components/link/link.theme.js
+++ b/lib/components/link/link.theme.js
@@ -1,6 +1,6 @@
 export const Link = {
   baseStyle: {
-    display: 'inline-block',
+    display: 'inline',
     boxShadow: 'none',
     _hover: {
       textDecoration: 'none',

--- a/lib/components/link/link.theme.js
+++ b/lib/components/link/link.theme.js
@@ -1,20 +1,13 @@
 export const Link = {
   baseStyle: {
     display: 'inline',
-    boxShadow: 'none',
+    outline: 'unset',
     _hover: {
       textDecoration: 'none',
     },
     _focus: {
       boxShadow: 'none',
       borderRadius: '2px',
-    },
-    _active: {
-      _focus: {
-        span: {
-          outline: 'none',
-        },
-      },
     },
   },
 };

--- a/lib/components/link/link.theme.js
+++ b/lib/components/link/link.theme.js
@@ -7,7 +7,14 @@ export const Link = {
     },
     _focus: {
       boxShadow: 'none',
-      borderRadius: '4px',
+      borderRadius: '2px',
+    },
+    _active: {
+      _focus: {
+        span: {
+          outline: 'none',
+        },
+      },
     },
   },
 };

--- a/lib/components/link/link.theme.js
+++ b/lib/components/link/link.theme.js
@@ -2,6 +2,9 @@ export const Link = {
   baseStyle: {
     display: 'inline-block',
     boxShadow: 'none',
+    _hover: {
+      textDecoration: 'none',
+    },
     _focus: {
       boxShadow: 'none',
       borderRadius: '4px',

--- a/lib/components/link/linktext.theme.js
+++ b/lib/components/link/linktext.theme.js
@@ -1,9 +1,6 @@
 import { colors } from '../../theme/colors.theme';
 
 export const LinkText = {
-  baseStyle: {
-    display: 'inline',
-  },
   sizes: {
     5: {
       fontSize: 5,
@@ -21,6 +18,24 @@ export const LinkText = {
       fontWeight: 7,
     },
   },
+  baseStyle: {
+    display: 'inline',
+    _groupFocus: {
+      outlineOffset: '0.25em',
+      textDecoration: 'none',
+      boxShadow: 'none',
+      border: 'none',
+      bg: 'none',
+      _hover: {
+        boxShadow: 'none',
+      },
+    },
+    _groupActive: {
+      textDecoration: 'none',
+      borderRadius: '0',
+      outline: 'none',
+    },
+  },
   variants: {
     primary: {
       color: 'purple.70',
@@ -28,24 +43,16 @@ export const LinkText = {
       _groupHover: {
         color: 'purple.70',
         bg: 'purple.10',
-        textDecoration: 'none',
         boxShadow: `${colors.purple[70]} 0 2px 0px 0px`,
       },
       _groupFocus: {
         color: 'purple.70',
-        textDecoration: 'none',
         outline: `${colors.purple[70]} auto 1px`,
-        outlineOffset: '4px',
-        boxShadow: 'none',
-        border: 'none',
-        bg: 'none',
       },
       _groupActive: {
         color: 'purple.90',
         bg: 'purple.30',
-        textDecoration: 'none',
         boxShadow: `${colors.purple[90]} 0 2px 0px 0px`,
-        borderRadius: '0',
       },
     },
     reverse: {
@@ -54,24 +61,16 @@ export const LinkText = {
       _groupHover: {
         color: 'grey.0',
         bg: 'grey.70',
-        textDecoration: 'none',
         boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
       },
       _groupFocus: {
         color: 'grey.0',
-        textDecoration: 'none',
         outline: `${colors.grey[0]} auto 1px`,
-        outlineOffset: '4px',
-        boxShadow: 'none',
-        border: 'none',
-        bg: 'none',
       },
       _groupActive: {
         color: 'grey.90',
         bg: 'grey.30',
-        textDecoration: 'none',
         boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
-        borderRadius: '0',
       },
     },
   },

--- a/lib/components/link/linktext.theme.js
+++ b/lib/components/link/linktext.theme.js
@@ -20,9 +20,9 @@ export const LinkText = {
   },
   baseStyle: {
     display: 'inline',
+    textDecoration: 'none',
     _groupFocus: {
       outlineOffset: '0.25em',
-      textDecoration: 'none',
       boxShadow: 'none',
       border: 'none',
       bg: 'none',
@@ -31,7 +31,6 @@ export const LinkText = {
       },
     },
     _groupActive: {
-      textDecoration: 'none',
       borderRadius: '0',
       outline: 'none',
     },
@@ -40,37 +39,37 @@ export const LinkText = {
     primary: {
       color: 'purple.70',
       boxShadow: `${colors.purple[70]} 0 1px 0px 0px`,
-      _groupHover: {
-        color: 'purple.70',
-        bg: 'purple.10',
-        boxShadow: `${colors.purple[70]} 0 2px 0px 0px`,
-      },
       _groupFocus: {
         color: 'purple.70',
         outline: `${colors.purple[70]} auto 1px`,
       },
-      _groupActive: {
-        color: 'purple.90',
-        bg: 'purple.30',
-        boxShadow: `${colors.purple[90]} 0 2px 0px 0px`,
+      _groupHover: {
+        color: 'purple.70',
+        bg: 'purple.10',
+        boxShadow: `${colors.purple[70]} 0 2px 0px 0px`,
+        _active: {
+          color: 'purple.90',
+          bg: 'purple.30',
+          boxShadow: `${colors.purple[90]} 0 2px 0px 0px`,
+        },
       },
     },
     reverse: {
       color: 'grey.0',
       boxShadow: `${colors.grey[0]} 0 1px 0px 0px`,
-      _groupHover: {
-        color: 'grey.0',
-        bg: 'grey.70',
-        boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
-      },
       _groupFocus: {
         color: 'grey.0',
         outline: `${colors.grey[0]} auto 1px`,
       },
-      _groupActive: {
-        color: 'grey.90',
-        bg: 'grey.30',
+      _groupHover: {
+        color: 'grey.0',
+        bg: 'grey.70',
         boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
+        _active: {
+          color: 'grey.90',
+          bg: 'grey.30',
+          boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
+        },
       },
     },
   },

--- a/lib/components/link/linktext.theme.js
+++ b/lib/components/link/linktext.theme.js
@@ -33,10 +33,12 @@ export const LinkText = {
       },
       _groupFocus: {
         color: 'purple.70',
-        bg: 'purple.10',
         textDecoration: 'none',
-        borderRadius: '4px',
-        boxShadow: `${colors.purple[10]} 0px 0px 0px 1px, ${colors.purple[70]} 0px 0px 0px 3px`,
+        outline: `${colors.purple[70]} auto 1px`,
+        outlineOffset: '4px',
+        boxShadow: 'none',
+        border: 'none',
+        bg: 'none',
       },
       _groupActive: {
         color: 'purple.90',
@@ -57,10 +59,12 @@ export const LinkText = {
       },
       _groupFocus: {
         color: 'grey.0',
-        bg: 'grey.70',
         textDecoration: 'none',
-        borderRadius: '4px',
-        boxShadow: `${colors.grey[70]} 0px 0px 0px 1px, ${colors.grey[0]} 0px 0px 0px 3px`,
+        outline: `${colors.grey[0]} auto 1px`,
+        outlineOffset: '4px',
+        boxShadow: 'none',
+        border: 'none',
+        bg: 'none',
       },
       _groupActive: {
         color: 'grey.90',

--- a/lib/components/link/linktext.theme.js
+++ b/lib/components/link/linktext.theme.js
@@ -24,12 +24,12 @@ export const LinkText = {
   variants: {
     primary: {
       color: 'purple.70',
-      boxShadow: `${colors.purple[70]} 0 -2px 0px -1px inset`,
+      boxShadow: `${colors.purple[70]} 0 1px 0px 0px`,
       _groupHover: {
         color: 'purple.70',
         bg: 'purple.10',
         textDecoration: 'none',
-        boxShadow: `${colors.purple[70]} 0 -2px 0px 0px inset`,
+        boxShadow: `${colors.purple[70]} 0 2px 0px 0px`,
       },
       _groupFocus: {
         color: 'purple.70',
@@ -44,18 +44,18 @@ export const LinkText = {
         color: 'purple.90',
         bg: 'purple.30',
         textDecoration: 'none',
-        boxShadow: `${colors.purple[90]} 0 -2px 0px 0px inset`,
+        boxShadow: `${colors.purple[90]} 0 2px 0px 0px`,
         borderRadius: '0',
       },
     },
     reverse: {
       color: 'grey.0',
-      boxShadow: `${colors.grey[0]} 0 -2px 0px -1px inset`,
+      boxShadow: `${colors.grey[0]} 0 1px 0px 0px`,
       _groupHover: {
         color: 'grey.0',
         bg: 'grey.70',
         textDecoration: 'none',
-        boxShadow: `${colors.grey[0]} 0 -2px 0px 0px inset`,
+        boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
       },
       _groupFocus: {
         color: 'grey.0',
@@ -70,7 +70,7 @@ export const LinkText = {
         color: 'grey.90',
         bg: 'grey.30',
         textDecoration: 'none',
-        boxShadow: `${colors.grey[0]} 0 -2px 0px 0px inset`,
+        boxShadow: `${colors.grey[0]} 0 2px 0px 0px`,
         borderRadius: '0',
       },
     },

--- a/lib/components/link/linktext.theme.js
+++ b/lib/components/link/linktext.theme.js
@@ -2,7 +2,7 @@ import { colors } from '../../theme/colors.theme';
 
 export const LinkText = {
   baseStyle: {
-    display: 'inline-block',
+    display: 'inline',
   },
   sizes: {
     5: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firehydrant/design-system",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Basically there was an issues with Links not wrapping correctly 

![image](https://user-images.githubusercontent.com/10525357/120380193-7bc97900-c2e6-11eb-9dee-6ab31c3776d8.png)

As well as an underline still appearing. This PR fixes both of those issues and adds it the changelog and bumps the version.

[Issue with Link text not following underline as well as hover state still showing an underline.](https://app.clubhouse.io/firehydrant/story/19042/issue-with-link-text-not-following-underline-as-well-as-hover-state-still-showing-an-underline)