### PR TITLE
Add the correct syntax to switch to __css

### DIFF
--- a/lib/components/checkbox/Checkbox.jsx
+++ b/lib/components/checkbox/Checkbox.jsx
@@ -19,7 +19,7 @@ export function Checkbox({ children, ...props }) {
   return (
     <ChakraCheckbox
       role="group"
-      sx={
+      __css={
         (props.isReadOnly || fieldProps.isReadOnly) && {
           '.chakra-checkbox__label': {
             color: 'grey.70',
@@ -31,7 +31,8 @@ export function Checkbox({ children, ...props }) {
         props.isIndeterminate ? <Icon name="minus" /> : <Icon name="check" />
       }
       {...fieldProps}
-      {...props}>
+      {...props}
+    >
       {children}
     </ChakraCheckbox>
   );

--- a/lib/components/checkbox/CheckboxGroup.jsx
+++ b/lib/components/checkbox/CheckboxGroup.jsx
@@ -6,7 +6,7 @@ export function CheckboxGroup({ children, horizontal, ...props }) {
     <ChakraCheckboxGroup {...props}>
       <Flex
         flexDir={horizontal ? 'row' : 'column'}
-        sx={
+        __css={
           horizontal
             ? {
                 '.chakra-checkbox': { mr: 3 },
@@ -20,7 +20,8 @@ export function CheckboxGroup({ children, horizontal, ...props }) {
                   mt: '0px',
                 },
               }
-        }>
+        }
+      >
         {children}
       </Flex>
     </ChakraCheckboxGroup>

--- a/lib/components/checkbox/CheckboxGroup.jsx
+++ b/lib/components/checkbox/CheckboxGroup.jsx
@@ -6,7 +6,7 @@ export function CheckboxGroup({ children, horizontal, ...props }) {
     <ChakraCheckboxGroup {...props}>
       <Flex
         flexDir={horizontal ? 'row' : 'column'}
-        __css={
+        sx={
           horizontal
             ? {
                 '.chakra-checkbox': { mr: 3 },

--- a/lib/components/checkbox/CheckboxGroup.jsx
+++ b/lib/components/checkbox/CheckboxGroup.jsx
@@ -2,19 +2,23 @@ import React from 'react';
 import { Flex, CheckboxGroup as ChakraCheckboxGroup } from '@chakra-ui/react';
 
 export function CheckboxGroup({ children, horizontal, ...props }) {
+  // display: flex needed see issue -> https://github.com/chakra-ui/chakra-ui/issues/2100
   return (
     <ChakraCheckboxGroup {...props}>
       <Flex
-        flexDir={horizontal ? 'row' : 'column'}
-        sx={
+        __css={
           horizontal
             ? {
+                display: 'flex',
+                flexDirection: 'row',
                 '.chakra-checkbox': { mr: 3 },
                 '.chakra-checkbox:last-of-type': {
                   mr: '0px',
                 },
               }
             : {
+                display: 'flex',
+                flexDirection: 'column',
                 '.chakra-checkbox': { mt: 'mg0' },
                 '.chakra-checkbox:first-of-type': {
                   mt: '0px',

--- a/lib/components/link/Link.jsx
+++ b/lib/components/link/Link.jsx
@@ -11,7 +11,7 @@ export function Link({ children, isExternal, size, variant, ...props }) {
       </LinkText>
       {isExternal && (
         <Icon
-          sx={{
+          __css={{
             color: variant === 'reverse' ? 'grey.0' : 'purple.70',
             ml: '4px',
             width: '1.5em',

--- a/lib/components/radio/Radio.jsx
+++ b/lib/components/radio/Radio.jsx
@@ -21,14 +21,15 @@ export function Radio({ children, ...props }) {
       display="inline-block"
       className="chakra-radio"
       role="group"
-      sx={
+      __css={
         (props.isReadOnly || fieldProps.isReadOnly) && {
           '.chakra-radio__label': {
             color: 'grey.70',
             cursor: 'not-allowed',
           },
         }
-      }>
+      }
+    >
       <ChakraRadio {...fieldProps} {...props}>
         {children}
       </ChakraRadio>

--- a/lib/components/radio/RadioGroup.jsx
+++ b/lib/components/radio/RadioGroup.jsx
@@ -6,7 +6,7 @@ export function RadioGroup({ children, horizontal, ...props }) {
     <ChakraRadioGroup {...props}>
       <Flex
         flexDir={horizontal ? 'row' : 'column'}
-        sx={
+        __css={
           horizontal
             ? {
                 '.chakra-radio': { mr: 3 },
@@ -20,7 +20,8 @@ export function RadioGroup({ children, horizontal, ...props }) {
                   mt: '0px',
                 },
               }
-        }>
+        }
+      >
         {children}
       </Flex>
     </ChakraRadioGroup>

--- a/lib/components/radio/RadioGroup.jsx
+++ b/lib/components/radio/RadioGroup.jsx
@@ -2,25 +2,30 @@ import React from 'react';
 import { Flex, RadioGroup as ChakraRadioGroup } from '@chakra-ui/react';
 
 export function RadioGroup({ children, horizontal, ...props }) {
+  // display: flex needed see issue -> https://github.com/chakra-ui/chakra-ui/issues/2100
   return (
     <ChakraRadioGroup {...props}>
       <Flex
-        flexDir={horizontal ? 'row' : 'column'}
-        sx={
+        __css={
           horizontal
             ? {
-                '.chakra-radio': { mr: '3' },
+                display: 'flex',
+                flexDirection: 'row',
+                '.chakra-radio': { mr: 3 },
                 '.chakra-radio:last-of-type': {
                   mr: '0px',
                 },
               }
             : {
+                display: 'flex',
+                flexDirection: 'column',
                 '.chakra-radio': { mt: 'mg0' },
                 '.chakra-radio:first-of-type': {
                   mt: '0px',
                 },
               }
-        }>
+        }
+      >
         {children}
       </Flex>
     </ChakraRadioGroup>

--- a/lib/components/radio/RadioGroup.jsx
+++ b/lib/components/radio/RadioGroup.jsx
@@ -6,10 +6,10 @@ export function RadioGroup({ children, horizontal, ...props }) {
     <ChakraRadioGroup {...props}>
       <Flex
         flexDir={horizontal ? 'row' : 'column'}
-        __css={
+        sx={
           horizontal
             ? {
-                '.chakra-radio': { mr: 3 },
+                '.chakra-radio': { mr: '3' },
                 '.chakra-radio:last-of-type': {
                   mr: '0px',
                 },
@@ -20,8 +20,7 @@ export function RadioGroup({ children, horizontal, ...props }) {
                   mt: '0px',
                 },
               }
-        }
-      >
+        }>
         {children}
       </Flex>
     </ChakraRadioGroup>


### PR DESCRIPTION
[SPIKE: Swap `sx` for `__css` in components](https://app.clubhouse.io/firehydrant/story/19036/spike-swap-sx-for-css-in-components)