### PR TITLE
Enables TurboSnaps

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,3 +32,5 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           # 👇 Option to prevent the workflow from failing
           exitZeroOnChanges: true
+          # 👇 Required for TurboSnaps feature
+          onlyChanged: true


### PR DESCRIPTION
Adds the `onlyChanged` flag to the chromatic GitHub action; this is a
requirement for TurboSnaps (Chromatic) to work properly.

Reference: https://www.chromatic.com/docs/turbosnap