### PR TITLE
fix(button): Remove x-spacing from tertiary variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage
 *.log
 .envrc
 storybook-static/
+
+# npm release cache
+~/.npm

--- a/lib/components/button/button.theme.js
+++ b/lib/components/button/button.theme.js
@@ -72,6 +72,7 @@ export const Button = {
     tertiary: {
       color: 'purple.70',
       bg: 'transparent',
+      p: 0,
       boxShadow: `inset 3px 3px 0px 0px transparent`,
       _hover: {
         color: 'purple.50',


### PR DESCRIPTION
This change removes the x-spacing (padding) from the tertiary Button
variant. It was discovered through design testing, that having this
extra negative space was doing more harm than good and would more than
likely result in overrides. See #[19508](https://app.clubhouse.io/firehydrant/story/19508/remove-x-spacing-from-tertiary-variant) for more details.

NOTE: This change will cause visual shifts on all instances of tertiary
button.