### PR TITLE
fix: Remove postinstall script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-react": "^7.23.1",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-testing-library": "^3.10.2",
+        "git-message": "^2.0.2",
         "jest": "^26.6.3",
         "playroom": "^0.23.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -13537,6 +13538,20 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/git-message": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/git-message/-/git-message-2.0.2.tgz",
+      "integrity": "sha1-60dFissLbXf85rGAPpeR71/4nGM=",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "async": "^2.1.4",
+        "ini": "^1.3.4"
+      },
+      "bin": {
+        "set-gitmessage": "bin/set-gitmessage.js"
       }
     },
     "node_modules/git-raw-commits": {
@@ -39061,6 +39076,16 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "git-message": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/git-message/-/git-message-2.0.2.tgz",
+      "integrity": "sha1-60dFissLbXf85rGAPpeR71/4nGM=",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.4",
+        "ini": "^1.3.4"
       }
     },
     "git-raw-commits": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "coverage": "jest --collectCoverage",
     "lint": "eslint src",
     "prerelease": "npm run build",
-    "release": "standard-version",
-    "postinstall": "git config --local commit.template ./.gitmessage"
+    "release": "standard-version"
   },
   "dependencies": {
     "@chakra-ui/react": "^1.6.0",
@@ -71,6 +70,7 @@
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.10.2",
+    "git-message": "^2.0.2",
     "jest": "^26.6.3",
     "playroom": "^0.23.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",


### PR DESCRIPTION
This attempts to address an issue in our docker environments, preventing
successful installation due to the postinstall script.

`git-message` should take the place of the postinstall script, achieving effectively the same desired outcome but eliminating what appears to be a problematic script (for docker environment). 