### PR TITLE
chore: Revert chromatic action

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -22,6 +22,15 @@
       "contributions": [
         "design"
       ]
+    },
+    {
+      "login": "nearbycoder",
+      "name": "Josh Hamilton",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10525357?v=4",
+      "profile": "https://nearbycoder.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,
@@ -30,5 +39,6 @@
   "projectOwner": "firehydrant",
   "repoType": "github",
   "repoHost": "https://github.com",
-  "skipCi": true
+  "skipCi": true,
+  "commitConvention": "none"
 }

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,11 @@
 name: 'Chromatic'
 
 # Event for the workflow
-on: push
+on: 
+  push:
+    branches-ignore:
+      # Do not run on dependabot branches
+      - 'dependabot/**'
 
 # List of jobs
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ Design System is intended to be maintained collaboratively by every engineer and
 - [5. Deploy secondary apps](#5-deploy-secondary-apps)
   - [5.1. Storybook](#51-storybook)
   - [5.2. Playroom](#52-playroom)
+- [Maintenance](#maintenance)
+  - [Upgrading dependencies](#upgrading-dependencies)
+      - [Manual deploy to Chromatic](#manual-deploy-to-chromatic)
 
 ---
 
@@ -158,6 +161,33 @@ On push, every branch is configured to automatically build & deploy to [Chromati
 ## 5.2. [Playroom][playroom]
 
 On push to `main`, Playroom is automatically built to `docs/`, pushed to branch: `gh-pages`, and deployed to GitHub Pages via ["Build & Deploy Playroom" GitHub Workflow](./.github/workflows/playroom.yml).
+
+# Maintenance
+
+## Upgrading dependencies
+
+Monitoring outdated dependencies is handled by [dependabot](https://github.com/firehydrant/design-system/network/updates) ↗️, which will automatically open PRs to upgrade packages; currently configured to a maximum of 5 at a given time.
+
+**Chromatic testing on a dependabot-triggered branch MUST be done manually.**
+
+Dependabot can no longer access project secrets, thus preventing the Chromatic action from running successfully on dependabot-triggered branches. ([source](https://github.com/dependabot/dependabot-core/issues/3253))
+
+_Chromatic testing of dependency updates is advised but not required, to the discretion of the merging maintainer._
+
+#### Manual deploy to Chromatic
+
+1. Checkout the dependabot branch you wish to test.
+
+   ```
+   git checkout dependabot/<branch-you-wish-to-test>
+   ```
+
+2. Create a build & push to Chromatic
+   ```
+   npx chromatic --project-token=<CHROMATIC_PROJECT_TOKEN>
+   ```
+
+Project tokens are found in Chromatic project settings under [Manage > Configure](https://www.chromatic.com/manage?appId=607731addb01d30021caeac2&view=configure) ↗️.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ Design System is intended to be maintained collaboratively by every engineer and
 - [5. Deploy secondary apps](#5-deploy-secondary-apps)
   - [5.1. Storybook](#51-storybook)
   - [5.2. Playroom](#52-playroom)
-- [Maintenance](#maintenance)
-  - [Upgrading dependencies](#upgrading-dependencies)
-      - [Manual deploy to Chromatic](#manual-deploy-to-chromatic)
+- [6. Maintenance](#6-maintenance)
+  - [6.1. Upgrading dependencies](#61-upgrading-dependencies)
+      - [6.1.0.1. Manual deploy to Chromatic](#6101-manual-deploy-to-chromatic)
 
 ---
 
@@ -162,9 +162,9 @@ On push, every branch is configured to automatically build & deploy to [Chromati
 
 On push to `main`, Playroom is automatically built to `docs/`, pushed to branch: `gh-pages`, and deployed to GitHub Pages via ["Build & Deploy Playroom" GitHub Workflow](./.github/workflows/playroom.yml).
 
-# Maintenance
+# 6. Maintenance
 
-## Upgrading dependencies
+## 6.1. Upgrading dependencies
 
 Monitoring outdated dependencies is handled by [dependabot](https://github.com/firehydrant/design-system/network/updates) ↗️, which will automatically open PRs to upgrade packages; currently configured to a maximum of 5 at a given time.
 
@@ -174,7 +174,7 @@ Dependabot can no longer access project secrets, thus preventing the Chromatic a
 
 _Chromatic testing of dependency updates is advised but not required, to the discretion of the merging maintainer._
 
-#### Manual deploy to Chromatic
+#### 6.1.0.1. Manual deploy to Chromatic
 
 1. Checkout the dependabot branch you wish to test.
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ For a list of all components & properties, refer to [Storybook][storybook] ↗�
 # contributors
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-![2 Contributors](https://img.shields.io/badge/all_contributors-2-614ab6.svg)
-
+![3 Contributors](https://img.shields.io/badge/all_contributors-3-614ab6.svg)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 We welcome all additions and modifications, check out the [Contribution Guidelines](./CONTRIBUTING.md) to get started.
@@ -94,6 +92,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="http://caseymhunt.com"><img src="https://avatars.githubusercontent.com/u/2065615?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Casey Hunt</b></sub></a><br /><a href="#maintenance-caseymhunt" title="Maintenance">🚧</a></td>
     <td align="center"><a href="http://jax.works"><img src="https://avatars.githubusercontent.com/u/6673768?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jax Engel</b></sub></a><br /><a href="#design-jaxatto" title="Design">🎨</a></td>
+    <td align="center"><a href="https://nearbycoder.com/"><img src="https://avatars.githubusercontent.com/u/10525357?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Josh Hamilton</b></sub></a><br /><a href="https://github.com/firehydrant/design-system/commits?author=nearbycoder" title="Code">💻</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
The Chromatic action in GitHub will not be able to run on dependabot triggered branches according to this change: https://github.com/dependabot/dependabot-core/issues/3253

As such, we are reverting back to ignoring `dependabot` triggered branches in the Chromatic action. 

**TODO**
- [x] update contrib docs for CLI chromatic testing prior to dependabot merging