### PR TITLE
fix(radio, checkbox): Deprecate defaultIsChecked

### DIFF
--- a/lib/components/checkbox/Checkbox.stories.js
+++ b/lib/components/checkbox/Checkbox.stories.js
@@ -53,7 +53,7 @@ export default {
         type: 'boolean',
       },
     },
-    defaultIsChecked: {
+    defaultChecked: {
       description: 'if checkbox is default checked',
       table: {
         type: { summary: 'bool' },

--- a/lib/components/radio/Radio.stories.js
+++ b/lib/components/radio/Radio.stories.js
@@ -43,7 +43,7 @@ export default {
         type: 'boolean',
       },
     },
-    defaultIsChecked: {
+    defaultChecked: {
       description: 'if radio is default checked',
       table: {
         type: { summary: 'bool' },


### PR DESCRIPTION
defaultIsChecked as a prop for Checkbox & Radio has been deprecated by
Chakra. Update docs to reflect this change.

BREAKING CHANGE: `defaultIsChecked` is deprecated; use `defaultChecked`