### PR TITLE
feat(tag): adds outline variant

### DIFF
--- a/lib/components/table/Table.stories.js
+++ b/lib/components/table/Table.stories.js
@@ -197,7 +197,7 @@ export const Badges = ({ args }) => (
         <Td>Banana</Td>
         <Td>Fruit</Td>
         <Td>
-          <Tag variant="success">
+          <Tag colorScheme="green">
             <TagLabel>Stocked</TagLabel>
           </Tag>
         </Td>
@@ -206,7 +206,7 @@ export const Badges = ({ args }) => (
         <Td>Apple</Td>
         <Td>Fruit</Td>
         <Td>
-          <Tag variant="alert">
+          <Tag colorScheme="red">
             <TagLabel>Out of stock</TagLabel>
           </Tag>
         </Td>
@@ -215,7 +215,7 @@ export const Badges = ({ args }) => (
         <Td>Potato</Td>
         <Td>Vegetable</Td>
         <Td>
-          <Tag variant="alert">
+          <Tag colorScheme="red">
             <TagLabel>Out of stock</TagLabel>
           </Tag>
         </Td>
@@ -224,7 +224,7 @@ export const Badges = ({ args }) => (
         <Td>Break</Td>
         <Td>Grain</Td>
         <Td>
-          <Tag variant="alert">
+          <Tag colorScheme="red">
             <TagLabel>Out of stock</TagLabel>
           </Tag>
         </Td>

--- a/lib/components/tag/Tag.stories.js
+++ b/lib/components/tag/Tag.stories.js
@@ -18,12 +18,21 @@ export default {
       defaultValue: 'grey',
       description: 'color scheme of the tag',
       table: {
-        type: { summary: 'grey|green|brown|red|purple|teal' },
+        type: { summary: 'grey|green|brown|red|purple|teal|orange|blue' },
         defaultValue: { summary: 'grey' },
       },
       control: {
         type: 'radio',
-        options: ['grey', 'green', 'brown', 'red', 'purple', 'teal'],
+        options: [
+          'grey',
+          'green',
+          'brown',
+          'red',
+          'purple',
+          'teal',
+          'orange',
+          'blue',
+        ],
       },
     },
     variant: {
@@ -80,6 +89,12 @@ export const colorSchemes = (args) => (
     </Tag>
     <Tag {...args} colorScheme="teal">
       teal
+    </Tag>
+    <Tag {...args} colorScheme="orange">
+      orange
+    </Tag>
+    <Tag {...args} colorScheme="blue">
+      blue
     </Tag>
   </Wrap>
 );

--- a/lib/components/tag/Tag.stories.js
+++ b/lib/components/tag/Tag.stories.js
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  InfoIcon,
-  SuccessIcon,
-  AlertIcon,
-  WarningIcon,
-  AccountIcon,
-  StarFilledIcon,
-} from '../../main';
+import { InfoIcon, Wrap } from '../../main';
 import { Tag, TagLabel, TagLeftIcon, TagRightIcon } from './index';
 
 export default {
@@ -19,94 +12,91 @@ export default {
         type: { summary: 'text|node' },
       },
     },
+    colorScheme: {
+      name: 'colorScheme',
+      type: { name: 'string', required: false },
+      defaultValue: 'grey',
+      description: 'color scheme of the tag',
+      table: {
+        type: { summary: 'grey|green|brown|red|purple|teal' },
+        defaultValue: { summary: 'grey' },
+      },
+      control: {
+        type: 'radio',
+        options: ['grey', 'green', 'brown', 'red', 'purple', 'teal'],
+      },
+    },
+    variant: {
+      name: 'variant',
+      type: { name: 'string', required: false },
+      defaultValue: 'subtle',
+      description: 'different visual types of tag',
+      table: {
+        type: { summary: 'subtle|outline' },
+        defaultValue: { summary: 'subtle' },
+      },
+      control: {
+        type: 'radio',
+        options: ['subtle', 'outline'],
+      },
+    },
   },
 };
 
-const Template = ({ children, ...args }) => (
+export const Default = ({ children, ...args }) => (
   <Tag {...args}>
     <TagLabel>{children}</TagLabel>
   </Tag>
 );
+Default.args = { children: 'Default' };
 
-export const DefaultTag = Template.bind({});
-DefaultTag.args = { children: 'Default' };
-
-export const DefaultIcon = () => (
-  <Tag>
-    <TagLeftIcon as={InfoIcon} />
-    <TagLabel>Default</TagLabel>
-  </Tag>
+export const Variants = (args) => (
+  <Wrap spacing={2} p={2} bg="white">
+    <Tag {...args} variant="subtle">
+      default / subtle
+    </Tag>
+    <Tag {...args} variant="outline">
+      outline
+    </Tag>
+  </Wrap>
 );
 
-export const DefaultIconRight = () => (
-  <Tag>
-    <TagLabel>Default</TagLabel>
-    <TagRightIcon as={InfoIcon} />
-  </Tag>
+export const colorSchemes = (args) => (
+  <Wrap spacing={2} p={2} bg="white">
+    <Tag {...args} colorScheme="grey">
+      grey
+    </Tag>
+    <Tag {...args} colorScheme="green">
+      green
+    </Tag>
+    <Tag {...args} colorScheme="brown">
+      brown
+    </Tag>
+    <Tag {...args} colorScheme="red">
+      red
+    </Tag>
+    <Tag {...args} colorScheme="purple">
+      purple
+    </Tag>
+    <Tag {...args} colorScheme="teal">
+      teal
+    </Tag>
+  </Wrap>
 );
 
-export const SuccessTag = Template.bind({});
-SuccessTag.args = { variant: 'success', children: 'Success' };
-
-export const SuccessIconTag = () => (
-  <Tag variant="success">
-    <TagLeftIcon as={SuccessIcon} />
-    <TagLabel>Success</TagLabel>
-  </Tag>
-);
-
-export const AlertTag = Template.bind({});
-AlertTag.args = { variant: 'alert', children: 'Alert' };
-
-export const AlertIconTag = () => (
-  <Tag variant="alert">
-    <TagLeftIcon as={AlertIcon} />
-    <TagLabel>Alert</TagLabel>
-  </Tag>
-);
-
-export const WarningTag = Template.bind({});
-WarningTag.args = { variant: 'warning', children: 'Warning' };
-
-export const WarningIconTag = () => (
-  <Tag variant="warning">
-    <TagLeftIcon as={WarningIcon} />
-    <TagLabel>Warning</TagLabel>
-  </Tag>
-);
-
-export const NeutralTag = Template.bind({});
-NeutralTag.args = { variant: 'neutral', children: 'Neutral' };
-
-export const NeutralIconTag = () => (
-  <Tag variant="neutral">
-    <TagLeftIcon as={InfoIcon} />
-    <TagLabel>Neutral</TagLabel>
-  </Tag>
-);
-
-export const AccentTealTag = Template.bind({});
-AccentTealTag.args = {
-  variant: 'accentTeal',
-  children: 'Accent Teal',
-};
-
-export const AccentTealIconTag = () => (
-  <Tag variant="accentTeal">
-    <TagLeftIcon as={AccountIcon} />
-    <TagLabel>Accent Teal</TagLabel>
-  </Tag>
-);
-
-export const AccentPurpleTag = Template.bind({});
-AccentPurpleTag.args = {
-  variant: 'accentPurple',
-  children: 'Accent Purple',
-};
-
-export const AccentPurpleIconTag = () => (
-  <Tag variant="accentPurple">
-    <TagLeftIcon as={StarFilledIcon} />
-    <TagLabel>Accent Purple</TagLabel>
-  </Tag>
+export const withIcon = (args) => (
+  <Wrap spacing={2} p={2} bg="white">
+    <Tag {...args}>
+      <TagLeftIcon>
+        <InfoIcon />
+      </TagLeftIcon>
+      <TagLabel>with icon</TagLabel>
+    </Tag>
+    <Tag {...args}>
+      <TagLabel>with right icon</TagLabel>
+      <TagRightIcon>
+        <InfoIcon />
+      </TagRightIcon>
+    </Tag>
+  </Wrap>
 );

--- a/lib/components/tag/tag.theme.js
+++ b/lib/components/tag/tag.theme.js
@@ -40,7 +40,8 @@ export const Tag = {
     },
   },
   defaultProps: {
-    variant: 'default',
+    variant: 'subtle',
+    colorScheme: 'grey',
     size: 'md',
   },
 };

--- a/lib/components/tag/tag.theme.js
+++ b/lib/components/tag/tag.theme.js
@@ -1,8 +1,12 @@
 export const Tag = {
-  baseStyle: {
-    container: {
-      border: '1px solid',
-    },
+  baseStyle: ({ colorScheme }) => {
+    return {
+      container: {
+        border: '1px solid',
+        borderColor:
+          colorScheme === 'teal' ? `${colorScheme}.90` : `${colorScheme}.70`,
+      },
+    };
   },
   sizes: {
     md: {
@@ -16,34 +20,23 @@ export const Tag = {
     },
   },
   variants: {
-    default: {
-      container: { color: 'grey.70', bg: 'grey.10', borderColor: 'grey.70' },
+    subtle: ({ colorScheme }) => {
+      return {
+        container: {
+          bg: `${colorScheme}.10`,
+          color:
+            colorScheme === 'teal' ? `${colorScheme}.90` : `${colorScheme}.70`,
+        },
+      };
     },
-    success: {
-      container: { color: 'green.70', bg: 'green.10', borderColor: 'green.70' },
-    },
-    alert: {
-      container: { color: 'red.70', bg: 'red.10', borderColor: 'red.70' },
-    },
-    warning: {
-      container: {
-        color: 'brown.70',
-        bg: 'brown.10',
-        borderColor: 'brown.70',
-      },
-    },
-    neutral: {
-      container: { color: 'grey.70', bg: 'grey.10', borderColor: 'grey.70' },
-    },
-    accentTeal: {
-      container: { color: 'teal.90', bg: 'teal.10', borderColor: 'teal.90' },
-    },
-    accentPurple: {
-      container: {
-        color: 'purple.70',
-        bg: 'purple.10',
-        borderColor: 'purple.70',
-      },
+    outline: ({ colorScheme }) => {
+      return {
+        container: {
+          color:
+            colorScheme === 'teal' ? `${colorScheme}.90` : `${colorScheme}.70`,
+          boxShadow: 'none',
+        },
+      };
     },
   },
   defaultProps: {

--- a/lib/recipes/LogInForm/Tags.stories.js
+++ b/lib/recipes/LogInForm/Tags.stories.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+  AlertIcon,
+  SuccessIcon,
+  WarningIcon,
+  InfoIcon,
+  Tag,
+  TagLeftIcon,
+  TagLabel,
+  Wrap,
+} from '../../main';
+
+export default {
+  title: 'Recipes/Status Tags',
+};
+
+export const Neutral = () => (
+  <Wrap spacing={2} p={2}>
+    <Tag colorScheme="grey">Neutral</Tag>
+    <Tag colorScheme="grey">
+      <TagLeftIcon>
+        <InfoIcon />
+      </TagLeftIcon>
+      <TagLabel>Neutral</TagLabel>
+    </Tag>
+  </Wrap>
+);
+
+export const Alert = () => (
+  <Wrap spacing={2} p={2}>
+    <Tag colorScheme="red">Alert</Tag>
+    <Tag colorScheme="red">
+      <TagLeftIcon>
+        <AlertIcon />
+      </TagLeftIcon>
+      <TagLabel>Alert</TagLabel>
+    </Tag>
+  </Wrap>
+);
+
+export const Warning = () => (
+  <Wrap spacing={2} p={2}>
+    <Tag colorScheme="brown">Warning</Tag>
+    <Tag colorScheme="brown">
+      <TagLeftIcon>
+        <WarningIcon />
+      </TagLeftIcon>
+      <TagLabel>Warning</TagLabel>
+    </Tag>
+  </Wrap>
+);
+
+export const Success = () => (
+  <Wrap spacing={2} p={2}>
+    <Tag colorScheme="green">Success</Tag>
+    <Tag colorScheme="green">
+      <TagLeftIcon>
+        <SuccessIcon />
+      </TagLeftIcon>
+      <TagLabel>Success</TagLabel>
+    </Tag>
+  </Wrap>
+);


### PR DESCRIPTION
This adds the outline variant styling to the Tag component. As a side
effect, the previous values for the `variant` prop are no longer valid.
Tag has been refactored to use the Chakra paradigm of `variant` and
`colorScheme` to choose a visual styling for Tag.

Valid values for `variant` are now: outline, subtle; `colorScheme` is
any valid color family from the foundations.

BREAKING CHANGE: any previous `variant` value is no longer valid. Tag
now expects `variant='[subtle | outline]'` and
`colorScheme='<foundation_color_family>'`.

--

Todo:

- [x] rebuild storybook stories
- [x] would be helpful to merge #84 for layout in Storybook