### PR TITLE
fix(Dropdown): pass provided styles to MenuList to set maxMenuHeight

### DIFF
--- a/lib/components/dropdown/Dropdown.jsx
+++ b/lib/components/dropdown/Dropdown.jsx
@@ -145,7 +145,8 @@ const customStyles = {
     marginBottom: '0',
     boxShadow: '4px 4px 0px 0px rgba(24, 32, 66, 0.16)',
   }),
-  menuList: () => ({
+  menuList: (provided) => ({
+    ...provided,
     padding: '0',
     border: `1px solid ${colors.grey[30]}`,
     borderRadius: radii['base'],


### PR DESCRIPTION
React Select sets `maxMenuHeight` to 300 by default, but as we were not passing the provided styles to our customStyles, the max-height was not being set. This fix can be seen in the "Searchable Options" and async stories.