### PR TITLE
docs(Storybook): custom blocks for space & radius

### DIFF
--- a/lib/components/alert/Alert.jsx
+++ b/lib/components/alert/Alert.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Flex, Spacer, useStyleConfig } from '@chakra-ui/react';
 import { Icon, IconButton, Text } from '../../main';
 
-export function Alert({ children, dismissable, onDismiss, variant }) {
+export function Alert({ children, dismissable, onDismiss, variant, ...rest }) {
   const styles = useStyleConfig('Alert', { variant });
 
   const iconColorScheme = {
@@ -19,6 +19,7 @@ export function Alert({ children, dismissable, onDismiss, variant }) {
       borderStyle="solid"
       borderRadius="4px"
       variant={variant}
+      {...rest}
     >
       <Flex>
         <Flex align="flex-start" py="mg2">

--- a/lib/components/alert/Alert.jsx
+++ b/lib/components/alert/Alert.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Flex, Spacer, useStyleConfig } from '@chakra-ui/react';
 import { Icon, IconButton, Text } from '../../main';
 
-export function Alert({ children, dismissable, onDismiss, variant, ...rest }) {
+export function Alert({
+  children,
+  dismissable,
+  onDismiss,
+  variant = 'info',
+  ...rest
+}) {
   const styles = useStyleConfig('Alert', { variant });
 
   const iconColorScheme = {
@@ -44,3 +51,9 @@ export function Alert({ children, dismissable, onDismiss, variant, ...rest }) {
     </Flex>
   );
 }
+
+Alert.propTypes = {
+  children: PropTypes.node,
+  variant: PropTypes.oneOf(['alert', 'info', 'success', 'warning']),
+  dismissable: PropTypes.bool,
+};

--- a/lib/components/alert/Alert.stories.js
+++ b/lib/components/alert/Alert.stories.js
@@ -8,9 +8,15 @@ export default {
   argTypes: {
     children: {
       description: 'Inner elements or text for element',
-      table: {
-        type: { summary: 'text|node' },
-      },
+    },
+    variant: {
+      description: 'Visual style of component',
+      options: ['info', 'success', 'warning', 'alert'],
+      control: { type: 'radio' },
+    },
+    dismissable: {
+      description: 'Adds close button to Alert',
+      control: { type: 'boolean' },
     },
   },
 };

--- a/lib/theme/space.stories.mdx
+++ b/lib/theme/space.stories.mdx
@@ -1,0 +1,24 @@
+import { Meta, Typeset } from '@storybook/addon-docs';
+import { SpacePalette, RadiiPalette } from './storybookBlocks';
+import { Box, Text, Alert } from '../main';
+import { space as spaces } from './space.theme';
+import { radii } from './radii.theme';
+
+<Meta title="Space &amp; Radii" />
+
+# Space & Radii
+
+Space & radii values available in Design System.
+
+## Space
+
+<SpacePalette spaces={spaces}>
+  <Alert variant="warning">
+    Notice: <code>mg</code> space values should be used for component
+    construction purposes only.
+  </Alert>
+</SpacePalette>
+
+## Radii
+
+<RadiiPalette radii={radii} />

--- a/lib/theme/space.stories.mdx
+++ b/lib/theme/space.stories.mdx
@@ -13,7 +13,7 @@ Space & radii values available in Design System.
 ## Space
 
 <SpacePalette spaces={spaces}>
-  <Alert variant="warning">
+  <Alert variant="warning" mb={4}>
     Notice: <code>mg</code> space values should be used for component
     construction purposes only.
   </Alert>

--- a/lib/theme/storybookBlocks.jsx
+++ b/lib/theme/storybookBlocks.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Text, Box } from '../main';
+
+export function SpacePalette({ spaces, children, ...rest }) {
+  return (
+    <Box my={4} {...rest}>
+      {children}
+      {Object.entries(spaces).map(([space, value], index) => {
+        return (
+          <Box as="figure" display="inline-block" mr={2} key={index}>
+            <Box role="img" w={value} h={value} bg="red.10" mb={1} />
+            <figcaption>
+              <code>{`${space}`}</code>
+              <br />
+              <Text size="7">({`${value}`})</Text>
+            </figcaption>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function RadiiPalette({ radii, children, ...rest }) {
+  return (
+    <Box my={4} {...rest}>
+      {children}
+      {Object.entries(radii).map(([radius, value], index) => {
+        return (
+          <Box as="figure" display="inline-block" mr={2} key={index}>
+            <Box
+              role="img"
+              w="48px"
+              h="48px"
+              bg="red.10"
+              mb={1}
+              borderRadius={radius}
+            />
+            <figcaption>
+              <code>{`${radius}`}</code>
+              <br />
+              <Text size="7">({`${value}`})</Text>
+            </figcaption>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
_tl;dr adds custom storybook components for space & radii display; adds a fix to `Alert` to handle `...rest` prop_

# Description of changes
In addition to adding a story to display the Space & Radii tokens, this change introduces custom storybook component blocks to aid in display of that information. 

Upon writing stories for Space, a bug in `<Alert>` was discovered that prevented passing [style props](https://chakra-ui.com/docs/features/style-props) to the component because the `...rest` prop was unhandled. This change now properly spreads that prop on the container. 

## Screenshot(s)
![screenshot of proposed changes](https://user-images.githubusercontent.com/2065615/140231876-acc178e4-d916-46ca-a4cd-c85dabe73191.png)
