### PR TITLE
feat(accordion): add exports of Accordion components from Chakra

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,6 +22,11 @@ export * from './components/textarea';
 export * from './components/textfield';
 export * from './helpers/ThemeProvider';
 export {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
   Box,
   Center,
   Circle,


### PR DESCRIPTION
I would like to use the Accordion components from Chakra instead of the react-strap Collapse currently in Laddertruck.