### PR TITLE
feature(alert): add new 'notice' theme to alert

### DIFF
--- a/lib/components/alert/Alert.jsx
+++ b/lib/components/alert/Alert.jsx
@@ -15,6 +15,7 @@ export function Alert({
   const iconColorScheme = {
     alert: 'red.70',
     info: 'grey.70',
+    notice: 'teal.70',
     success: 'green.70',
     warning: 'brown.70',
   };
@@ -30,7 +31,7 @@ export function Alert({
     >
       <Flex>
         <Flex align="flex-start" py="mg2">
-          <Icon name={variant} ml="1" mr="2" color={iconColorScheme[variant]} />
+          <Icon name={variant || 'info'} ml="1" mr="2" color={iconColorScheme[variant]} />
           <Text color="grey.90" size="5" mb="0">
             {children}
           </Text>
@@ -54,6 +55,6 @@ export function Alert({
 
 Alert.propTypes = {
   children: PropTypes.node,
-  variant: PropTypes.oneOf(['alert', 'info', 'success', 'warning']),
+  variant: PropTypes.oneOf(['alert', 'info', 'notice', 'success', 'warning']),
   dismissable: PropTypes.bool,
 };

--- a/lib/components/alert/Alert.stories.js
+++ b/lib/components/alert/Alert.stories.js
@@ -26,6 +26,9 @@ const Template = ({ children, ...args }) => <Alert {...args}>{children}</Alert>;
 export const NeutralAlert = Template.bind({});
 NeutralAlert.args = { variant: 'info', children: 'Neutral text' };
 
+export const NoticeAlert = Template.bind({});
+NoticeAlert.args = { variant: 'notice', children: 'Notice text' };
+
 export const SuccessAlert = Template.bind({});
 SuccessAlert.args = {
   variant: 'success',

--- a/lib/components/alert/alert.theme.js
+++ b/lib/components/alert/alert.theme.js
@@ -12,6 +12,10 @@ export const Alert = {
       bg: 'grey.10',
       borderColor: 'grey.70',
     },
+    notice: {
+      bg: 'teal.10',
+      borderColor: 'teal.70',
+    },
     success: {
       bg: 'green.10',
       borderColor: 'green.70',


### PR DESCRIPTION
Add new color treatment for "notice" alerts, used in notifications for advanced trial. See GitHub issue [here](https://github.com/firehydrant/laddertruck/issues/4209).
![image](https://user-images.githubusercontent.com/42321596/152050403-ec9c7333-d098-486c-a210-038b17b3133a.png)
