### PR TITLE
Remove underline on hover. Make inactive tab backgrounds transparent.

### DIFF
--- a/lib/components/tabs/tabs.theme.js
+++ b/lib/components/tabs/tabs.theme.js
@@ -61,6 +61,7 @@ export const Tabs = {
       return {
         tab: {
           fontWeight: 'normal',
+          bg: 'transparent',
           _active: {
             color: 'grey.70',
           },
@@ -84,7 +85,6 @@ export const Tabs = {
           _hover: {
             bg: 'purple.10',
             color: 'purple.50',
-            boxShadow: `${colors.purple[50]} ${boxShadowOrientation}`,
           },
         },
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firehydrant/design-system",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Per review by design, the inactive tabs should not have the default background grey color, and we don't want enclosed tabs to have the purple underline on hover.

https://user-images.githubusercontent.com/10586810/162509899-f4a92027-4127-48a1-941f-999b4f585c40.mov

