### PR TITLE
Fix vertical alignment of value in dropdown.

### DIFF
--- a/lib/components/dropdown/Dropdown.jsx
+++ b/lib/components/dropdown/Dropdown.jsx
@@ -106,6 +106,7 @@ const customStyles = {
   }),
   singleValue: (provided) => ({
     ...provided,
+    position: 'absolute',
     fontSize: fontSizes[5],
     lineHeight: lineHeights[5],
     fontWeight: fontWeights[5],

--- a/lib/components/dropdown/Dropdown.stories.js
+++ b/lib/components/dropdown/Dropdown.stories.js
@@ -105,6 +105,14 @@ Default.args = {
   onChange: (opt) => console.log('options', opt),
 };
 
+export const DefaultWithValue = Template.bind({});
+DefaultWithValue.args = {
+  options: defaultOptions,
+  placeholder: 'Dropdown',
+  value: { value: 'two', label: 'Two' },
+  onChange: (opt) => console.log('options', opt),
+};
+
 export const MultiDropdown = Template.bind({});
 MultiDropdown.args = {
   options: longOptions,

--- a/lib/components/dropdown/Dropdown.stories.js
+++ b/lib/components/dropdown/Dropdown.stories.js
@@ -109,7 +109,7 @@ export const DefaultWithValue = Template.bind({});
 DefaultWithValue.args = {
   options: defaultOptions,
   placeholder: 'Dropdown',
-  value: { value: 'two', label: 'Two' },
+  defaultValue: { value: 'two', label: 'Two' },
   onChange: (opt) => console.log('options', opt),
 };
 


### PR DESCRIPTION
Text in dropdowns was not aligned properly after react-select upgrade.

**Chromatic link**
https://607731addb01d30021caeac2-tgrgypthbw.chromatic.com/?path=/story/components-forms-dropdown--default-with-value

**Before:** 

https://user-images.githubusercontent.com/10586810/163841603-38d04ce4-9dfa-419e-bf98-5946f5659413.mov

**After:**

https://user-images.githubusercontent.com/10586810/163841701-d3d65cd6-924a-4b15-987c-890f502a8289.mov

**New story with value**

<img width="692" alt="Screen Shot 2022-04-18 at 9 58 42 AM" src="https://user-images.githubusercontent.com/10586810/163846129-16d9d21b-9c50-4e7d-8fca-edbe5b842b7b.png">


