### PR TITLE
fix(popover): export components

### DIFF
--- a/lib/components/popover/index.js
+++ b/lib/components/popover/index.js
@@ -1,1 +1,2 @@
 export * from './PopoverDialog';
+export * from './PopoverInput';

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,7 @@ export * from './components/iconbutton';
 export * from './components/icons';
 export * from './components/link';
 export * from './components/menu';
+export * from './components/popover';
 export * from './components/radio';
 export * from './components/switch';
 export * from './components/table';


### PR DESCRIPTION
Exporting components made [here](https://github.com/firehydrant/design-system/pull/249). 