### PR TITLE
chore(AspectRatio): add AspectRatio to chakra exports

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -28,6 +28,7 @@ export {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  AspectRatio,
   Box,
   Center,
   Circle,


### PR DESCRIPTION
Add `AspectRatio` in anticipation of a responsive video walkthrough component.